### PR TITLE
Fix: Modify shouldExclude function to match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "Draw Folder Structure" extension will be documented in this file.
 
+## [1.2.2] - 2023-12-26
+
+### Added
+
+Fix error in shouldExclude function
+
 ## [1.2.1] - 2023-11-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "Draw Folder Structure" extension will be documented in this file.
 
+## [1.2.1] - 2023-11-16
+
+### Added
+
+Fix error in README.md
+
 ## [1.2.0] - 2023-11-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can modify it to your liking!
 
 Choose from a lot of predefined designs we have to offer. By default we use "EmojiDashes".
 
-#####list of styles:
+**List of styles:**
 
 - ClassicDashes
 - SparklesDesing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "drawfolderstructure",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "drawfolderstructure",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "drawfolderstructure",
   "displayName": "Draw Folder Structure",
   "description": "Generate markdown representations of your folder and file structure",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/krivoox/draw-folder-structure"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "drawfolderstructure",
   "displayName": "Draw Folder Structure",
   "description": "Generate markdown representations of your folder and file structure",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/krivoox/draw-folder-structure"

--- a/src/functions/should-exclude.ts
+++ b/src/functions/should-exclude.ts
@@ -1,3 +1,3 @@
 export function shouldExclude(name: string, patterns: string[]): boolean {
-  return patterns.some((pattern) => name.includes(pattern));
+  return patterns.some((pattern) => name === pattern);
 }


### PR DESCRIPTION
string patterns exactly

Body: Altered the shouldExclude function to strictly match name with the
given pattern, instead of merely checking if name includes the pattern.
This change prevents inadvertent exclusions when a pattern happens to
form a part of a string unexpectedly, thus improving the function's