### PR TITLE
fix: correct default exclude patterns for .git and .next

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Create .env file
         run: |
-          echo "TELEMETRY_CONNECTION_STRING=${{ secrets.AZURE_TELEMETRY_CONNECTION_STRING }}" > .env
+          echo "AZURE_INSIGHTS_CONNECTION_STRING=${{ secrets.AZURE_TELEMETRY_CONNECTION_STRING }}" > .env
         env:
           AZURE_TELEMETRY_CONNECTION_STRING: ${{ secrets.AZURE_TELEMETRY_CONNECTION_STRING }}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drawfolderstructure",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drawfolderstructure",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "dependencies": {
         "applicationinsights": "^3.7.0",
         "dotenv": "^17.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "drawfolderstructure",
   "displayName": "Draw Folder Structure",
   "description": "Generate markdown representations of your folder and file structure",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/krivoox/draw-folder-structure"


### PR DESCRIPTION
Wildcard patterns prevented these folders from being properly excluded.

<img width="834" height="246" alt="1765777563" src="https://github.com/user-attachments/assets/a16dd54d-b4dc-48a7-8582-f73fca0e53ba" />

<img width="833" height="230" alt="1765777617" src="https://github.com/user-attachments/assets/5b3af6d4-3434-4095-899c-04ae60acf1fe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated folder structure exclusion patterns to properly target directories instead of files, improving accuracy of folder structure displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->